### PR TITLE
doc: add lua-mysql install example

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         sudo /etc/init.d/mysql start
         mysql -e 'CREATE DATABASE ${{ env.MYSQL_DB }};' -u${{ env.MYSQL_USER }} -p${{ env.MYSQL_PASSWORD }}
-        luarocks install casbin
+        luarocks install https://raw.githubusercontent.com/casbin/lua-casbin/master/casbin-1.41.1-1.rockspec
         sudo apt install sqlite3 libsqlite3-dev lua-sql-mysql libpq-dev
         luarocks install luasql-mysql MYSQL_INCDIR=/usr/include/mysql/
         luarocks install luasql-postgres PGSQL_INCDIR=/usr/include/postgresql/ 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,17 @@ jobs:
         mysql -e 'CREATE DATABASE ${{ env.MYSQL_DB }};' -u${{ env.MYSQL_USER }} -p${{ env.MYSQL_PASSWORD }}
         luarocks install https://raw.githubusercontent.com/casbin/lua-casbin/master/casbin-1.41.1-1.rockspec
         sudo apt install sqlite3 libsqlite3-dev lua-sql-mysql libpq-dev
-        luarocks install luasql-mysql MYSQL_INCDIR=/usr/include/mysql/
-        luarocks install luasql-postgres PGSQL_INCDIR=/usr/include/postgresql/ 
-        luarocks install luasql-sqlite3
+        # install luasql driver
+        sudo git clone https://github.com/lunarmodules/luasql.git
+        cd luasql/rockspec
+        sudo cp ./luasql-mysql-2.6.0-1.rockspec ../luasql-mysql-2.6.0-1.rockspec
+        sudo cp ./luasql-postgres-2.6.0-1.rockspec ../luasql-postgres-2.6.0-1.rockspec
+        sudo cp ./luasql-sqlite3-2.6.0-1.rockspec ../luasql-sqlite3-2.6.0-1.rockspec
+        cd ..
+        luarocks make luasql-mysql-2.6.0-1.rockspec MYSQL_INCDIR=/usr/include/mysql/
+        luarocks make luasql-postgres-2.6.0-1.rockspec PGSQL_INCDIR=/usr/include/postgresql/
+        luarocks make luasql-sqlite3-2.6.0-1.rockspec
+        cd ..
         luarocks install busted
         luarocks install busted-htest
         luarocks install luacov-coveralls

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ First, install the corresponding driver of LuaSQL from LuaRocks based on the dat
 - For PostgreSQL, install luasql-postgres.
 - For SQLite3, install luasql-sqlite3.
 
+Take installing luasql-mysql for example, others are similar: 
+- If there is no mysql locally, please install it locally.
+- Run `whereis mysql` to find your mysql path, then cd into th path to find include path and lib path.
+  ```shell
+  [root@master ~]# whereis mysql
+  mysql: /usr/bin/mysql /usr/local/mysql
+  ```
+- Use mysql include path and lib path to install luasql-mysql. Run `luarocks install luasql-mysql MYSQL_INCDIR=/usr/local/mysql/include MYSQL_LIBDIR=/usr/local/mysql/lib`
+
 Then install the casbin-adapter from LuaRocks by
 ```bash
 sudo luarocks install https://raw.githubusercontent.com/casbin-lua/luasql-adapter/master/casbin-adapter-1.0.0-1.rockspec


### PR DESCRIPTION
The lua-mysql installation requires mysql to be installed locally. If the user does not know it, the installation will fail, which will cause them confusion.
So I add a luasql-mysql installation example.